### PR TITLE
Refactor dictionary to use metadata

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.3.0
+
+* Refactor Dictionary to use DictionaryEntry objects, which can store additional metadata
+
 ## 0.2.0
 
 * Rename Chainset/Chain to Corpus (better name is better)

--- a/lib/markovian/corpus/chain.rb
+++ b/lib/markovian/corpus/chain.rb
@@ -11,7 +11,6 @@ module Markovian
         @two_key_dictionary = Dictionary.new
       end
 
-      attr_reader :one_key_dictionary, :two_key_dictionary
       def lengthen(word, next_word:, previous_word: nil)
         @one_key_dictionary.push(word, next_word)
         @two_key_dictionary.push(two_word_key(previous_word, word), next_word)
@@ -33,6 +32,9 @@ module Markovian
 
       protected
 
+      # for equality checking
+      attr_reader :one_key_dictionary, :two_key_dictionary
+
       def result_for_two_words(previous_word, word)
         @two_key_dictionary.next_word(two_word_key(previous_word, word)) if previous_word
       end
@@ -49,4 +51,3 @@ module Markovian
     end
   end
 end
-

--- a/lib/markovian/corpus/dictionary.rb
+++ b/lib/markovian/corpus/dictionary.rb
@@ -1,17 +1,20 @@
-# This class represents a dictionary of words or phrases and the various words that can follow
-# them.  Currently it's implemented as a hash of arrays, but more advanced representations may
-# follow.
+require 'markovian/corpus/dictionary_entry'
 #
-# The key is an opaque value, which could represent either a single word or a phrase as desired.
+# This class represents a dictionary of words or phrases and the various words that can follow
+# them. The key is an opaque value, which could represent either a single word or a phrase as desired.
 module Markovian
   class Corpus
     class Dictionary
-      def push(key, word)
-        dictionary[key] += [word]
+      def push(key, word, direction: :forwards)
+        dictionary[key].push(word, direction: direction)
       end
 
       def next_word(key)
-        dictionary[key].sample
+        dictionary[key].next_word
+      end
+
+      def previous_word(key)
+        dictionary[key].previous_word
       end
 
       def random_word
@@ -32,7 +35,9 @@ module Markovian
       protected
 
       def dictionary
-        @dictionary ||= Hash.new([])
+        # We have to set the value of the hash in the block, otherwise it doesn't actually seem to
+        # get saved properly. Default hash values behave weirdly in general.
+        @dictionary ||= Hash.new {|hash, key| hash[key] = DictionaryEntry.new(key)}
       end
     end
   end

--- a/lib/markovian/corpus/dictionary_entry.rb
+++ b/lib/markovian/corpus/dictionary_entry.rb
@@ -1,0 +1,44 @@
+module Markovian
+  class Corpus
+    class DictionaryEntry
+      attr_reader :word, :count
+      def initialize(word)
+        @word = word
+        @next_words = []
+        @previous_words = []
+        @count = 0
+      end
+
+      def push(word, direction: :forwards)
+        array_for_direction(direction) << word
+        # we don't want to double-count words if we read the text both forward and backward, so
+        # only count in the forward direction. (If we encounter a scenario where someone only wants
+        # to read in the backward direction, we can deal with that then.)
+        @count += 1 if direction == :forwards
+      end
+
+      def next_word
+        next_words.sample
+      end
+
+      def previous_word
+        previous_words.sample
+      end
+
+      def ==(other)
+        self.word == other.word &&
+          self.next_words == other.next_words &&
+          self.previous_words == other.previous_words
+      end
+
+      protected
+
+      # for equality checking
+      attr_reader :next_words, :previous_words
+
+      def array_for_direction(direction)
+        direction == :backwards ? previous_words : next_words
+      end
+    end
+  end
+end

--- a/lib/markovian/corpus/dictionary_entry.rb
+++ b/lib/markovian/corpus/dictionary_entry.rb
@@ -36,8 +36,17 @@ module Markovian
       # for equality checking
       attr_reader :next_words, :previous_words
 
+      VALID_DIRECTIONS = [:backwards, :forwards]
+
       def array_for_direction(direction)
+        validate_direction(direction)
         direction == :backwards ? previous_words : next_words
+      end
+
+      def validate_direction(direction)
+        unless VALID_DIRECTIONS.include?(direction)
+          raise ArgumentError.new("Invalid direction #{direction.inspect}, valid directions are #{VALID_DIRECTIONS.inspect}")
+        end
       end
     end
   end

--- a/lib/markovian/version.rb
+++ b/lib/markovian/version.rb
@@ -1,3 +1,3 @@
 module Markovian
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/lib/corpus/chain_spec.rb
+++ b/spec/lib/corpus/chain_spec.rb
@@ -77,7 +77,11 @@ module Markovian
         it "asks the one-key dictionary for a random word", temporary_srand: 35 do
           chain.lengthen(word, next_word: word_association)
           chain.lengthen(word_association, next_word: word)
-          expect(3.times.map { chain.random_word }).to eq([word, word_association, word_association])
+          if RUBY_PLATFORM == "java"
+            expect(3.times.map { chain.random_word }).to eq([word, word, word_association])
+          else
+            expect(3.times.map { chain.random_word }).to eq([word, word_association, word_association])
+          end
         end
       end
 

--- a/spec/lib/corpus/chain_spec.rb
+++ b/spec/lib/corpus/chain_spec.rb
@@ -74,10 +74,10 @@ module Markovian
       end
 
       describe "#random_word" do
-        it "asks the one-key dictionary for a random word" do
-          result = double("random word")
-          allow(chain.one_key_dictionary).to receive(:random_word).and_return(result)
-          expect(chain.random_word).to eq(result)
+        it "asks the one-key dictionary for a random word", temporary_srand: 35 do
+          chain.lengthen(word, next_word: word_association)
+          chain.lengthen(word_association, next_word: word)
+          expect(3.times.map { chain.random_word }).to eq([word, word_association, word_association])
         end
       end
 

--- a/spec/lib/corpus/dictionary_entry_spec.rb
+++ b/spec/lib/corpus/dictionary_entry_spec.rb
@@ -39,7 +39,7 @@ module Markovian
               entry.push(next_word)
               entry.push(other_word)
               if RUBY_PLATFORM == "java"
-                result = [next_word, next_word, next_word, other_word, other_word, next_word, word]
+                result = [next_word, other_word, other_word, other_word, other_word, next_word, next_word]
               else
                 result = [next_word, next_word, other_word, next_word, other_word, next_word, other_word]
               end
@@ -68,7 +68,7 @@ module Markovian
               entry.push(next_word, direction: :backwards)
               entry.push(other_word, direction: :backwards)
               if RUBY_PLATFORM == "java"
-                result = [next_word, next_word, next_word, other_word, other_word, next_word, word]
+                result = [next_word, other_word, other_word, other_word, other_word, next_word, next_word]
               else
                 result = [next_word, next_word, other_word, next_word, other_word, next_word, other_word]
               end

--- a/spec/lib/corpus/dictionary_entry_spec.rb
+++ b/spec/lib/corpus/dictionary_entry_spec.rb
@@ -14,6 +14,10 @@ module Markovian
         end
 
         describe "pushing and retrieving words" do
+          it "raises an error if the direction is invalid" do
+            expect { entry.push(next_word, direction: :sideways) }.to raise_exception(ArgumentError)
+          end
+
           context "going forward (the default)" do
             it "returns the next word if desired" do
               # since there's only one word it'll always return the same value
@@ -46,23 +50,23 @@ module Markovian
           context "going backward" do
             it "returns the next word if desired" do
               # since there's only one word it'll always return the same value
-              entry.push(next_word, direction: :backward)
+              entry.push(next_word, direction: :backwards)
               expect(entry.previous_word).to eq(next_word)
             end
 
             it "doesn't populate the forward entries" do
-              entry.push(next_word, direction: :backward)
+              entry.push(next_word, direction: :backwards)
               expect(entry.next_word).to be_nil
             end
 
             it "doesn't increase the seen count" do
-              expect { 3.times { entry.push(next_word, direction: :backward) } }.not_to change { entry.count }
+              expect { 3.times { entry.push(next_word, direction: :backwards) } }.not_to change { entry.count }
             end
 
             it "samples from the entered words", temporary_srand: 17 do
               # fix the order of sampling so we can reproduce the test
-              entry.push(next_word, direction: :backward)
-              entry.push(other_word, direction: :backward)
+              entry.push(next_word, direction: :backwards)
+              entry.push(other_word, direction: :backwards)
               if RUBY_PLATFORM == "java"
                 result = [next_word, next_word, next_word, other_word, other_word, next_word, word]
               else

--- a/spec/lib/corpus/dictionary_entry_spec.rb
+++ b/spec/lib/corpus/dictionary_entry_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+
+module Markovian
+  class Corpus
+    class Chain
+      RSpec.describe DictionaryEntry do
+        let(:word) { Faker::Lorem.word }
+        let(:entry) { DictionaryEntry.new(word) }
+        let(:next_word) { Faker::Lorem.word }
+        let(:other_word) { Faker::Lorem.word }
+
+        it "initializes the count to 0" do
+          expect(entry.count).to eq(0)
+        end
+
+        describe "pushing and retrieving words" do
+          context "going forward (the default)" do
+            it "returns the next word if desired" do
+              # since there's only one word it'll always return the same value
+              entry.push(next_word)
+              expect(entry.next_word).to eq(next_word)
+            end
+
+            it "doesn't populate the previous entries" do
+              entry.push(next_word)
+              expect(entry.previous_word).to be_nil
+            end
+
+            it "increases the seen count" do
+              expect { 3.times { entry.push(next_word) } }.to change { entry.count }.from(0).to(3)
+            end
+
+            it "samples from the entered words", temporary_srand: 17 do
+              # fix the order of sampling so we can reproduce the test
+              entry.push(next_word)
+              entry.push(other_word)
+              if RUBY_PLATFORM == "java"
+                result = [next_word, next_word, next_word, other_word, other_word, next_word, word]
+              else
+                result = [next_word, next_word, other_word, next_word, other_word, next_word, other_word]
+              end
+              expect(7.times.map { entry.next_word }).to eq(result)
+            end
+          end
+
+          context "going backward" do
+            it "returns the next word if desired" do
+              # since there's only one word it'll always return the same value
+              entry.push(next_word, direction: :backward)
+              expect(entry.previous_word).to eq(next_word)
+            end
+
+            it "doesn't populate the forward entries" do
+              entry.push(next_word, direction: :backward)
+              expect(entry.next_word).to be_nil
+            end
+
+            it "doesn't increase the seen count" do
+              expect { 3.times { entry.push(next_word, direction: :backward) } }.not_to change { entry.count }
+            end
+
+            it "samples from the entered words", temporary_srand: 17 do
+              # fix the order of sampling so we can reproduce the test
+              entry.push(next_word, direction: :backward)
+              entry.push(other_word, direction: :backward)
+              if RUBY_PLATFORM == "java"
+                result = [next_word, next_word, next_word, other_word, other_word, next_word, word]
+              else
+                result = [next_word, next_word, other_word, next_word, other_word, next_word, other_word]
+              end
+              expect(7.times.map { entry.previous_word }).to eq(result)
+            end
+          end
+        end
+
+        describe "#==" do
+          it "is equal if the word and both directions are the same" do
+            entry.push(next_word)
+            entry.push(other_word, direction: :backwards)
+            other_entry = DictionaryEntry.new(word)
+            other_entry.push(next_word)
+            other_entry.push(other_word, direction: :backwards)
+            expect(entry).to eq(other_entry)
+          end
+
+          it "is not equal if the base word is different" do
+            entry.push(next_word)
+            entry.push(other_word, direction: :backwards)
+            other_entry = DictionaryEntry.new(Faker::Lorem.word)
+            other_entry.push(next_word)
+            other_entry.push(other_word, direction: :backwards)
+            expect(entry).not_to eq(other_entry)
+          end
+
+          it "is not equal if the forward direction is different" do
+            entry.push(next_word)
+            entry.push(other_word, direction: :backwards)
+            other_entry = DictionaryEntry.new(word)
+            other_entry.push(Faker::Lorem.word)
+            other_entry.push(other_word, direction: :backwards)
+            expect(entry).not_to eq(other_entry)
+          end
+
+          it "is not equal if the backward direction is different" do
+            entry.push(next_word)
+            entry.push(other_word, direction: :backwards)
+            other_entry = DictionaryEntry.new(word)
+            other_entry.push(next_word)
+            other_entry.push(Faker::Lorem.word, direction: :backwards)
+            expect(entry).not_to eq(other_entry)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/corpus/dictionary_spec.rb
+++ b/spec/lib/corpus/dictionary_spec.rb
@@ -9,23 +9,35 @@ module Markovian
         let(:word) { Faker::Lorem.word }
         let(:word2) { Faker::Lorem.word }
 
-        describe "push/next_word" do
-          it "returns the word for the phrase" do
-            # since there's only one word it'll always return the one word
-            dictionary.push(phrase, word)
-            expect(dictionary.next_word(phrase)).to eq(word)
+        describe "next_word" do
+          it "pushes a word to the appropriate dictionary entry (forwards default)" do
+            expect_any_instance_of(DictionaryEntry).to receive(:push).with(word2, direction: :forwards) do |entry|
+              expect(entry.word).to eq(word)
+            end
+            dictionary.push(word, word2)
           end
 
-          it "samples from the remaining words", temporary_srand: 17 do
-            # fix the order of sampling so we can reproduce the test
+          it "will push backwards if specified" do
+            expect_any_instance_of(DictionaryEntry).to receive(:push).with(word2, direction: :backwards) do |entry|
+              expect(entry.word).to eq(word)
+            end
+            dictionary.push(word, word2, direction: :backwards)
+          end
+        end
+
+        describe "#next_word" do
+          it "gets an appropriate word", temporary_srand: 21 do
             dictionary.push(phrase, word)
             dictionary.push(phrase, word2)
-            if RUBY_PLATFORM == "java"
-              result = [word2, word2, word2, word, word, word2, word]
-            else
-              result = [word, word2, word, word2, word, word2, word]
-            end
-            expect(7.times.map { dictionary.next_word(phrase) }).to eq(result)
+            expect(3.times.map { dictionary.next_word(phrase)}).to eq([word, word2, word])
+          end
+        end
+
+        describe "#previous_word" do
+          it "gets an appropriate word", temporary_srand: 21 do
+            dictionary.push(phrase, word, direction: :backwards)
+            dictionary.push(phrase, word2, direction: :backwards)
+            expect(3.times.map { dictionary.previous_word(phrase)}).to eq([word, word2, word])
           end
         end
 

--- a/spec/lib/corpus/dictionary_spec.rb
+++ b/spec/lib/corpus/dictionary_spec.rb
@@ -29,7 +29,8 @@ module Markovian
           it "gets an appropriate word", temporary_srand: 21 do
             dictionary.push(phrase, word)
             dictionary.push(phrase, word2)
-            expect(3.times.map { dictionary.next_word(phrase)}).to eq([word, word2, word])
+            result = RUBY_PLATFORM == "java" ? [word, word, word2] : [word, word2, word]
+            expect(3.times.map { dictionary.next_word(phrase)}).to eq(result)
           end
         end
 
@@ -37,7 +38,8 @@ module Markovian
           it "gets an appropriate word", temporary_srand: 21 do
             dictionary.push(phrase, word, direction: :backwards)
             dictionary.push(phrase, word2, direction: :backwards)
-            expect(3.times.map { dictionary.previous_word(phrase)}).to eq([word, word2, word])
+            result = RUBY_PLATFORM == "java" ? [word, word, word2] : [word, word2, word]
+            expect(3.times.map { dictionary.previous_word(phrase)}).to eq(result)
           end
         end
 


### PR DESCRIPTION
In order to handle punctuation, the Dictionary can't just store a hash of strings -- it has to store a hash of metadata, from which punctuation, sentence flow, etc. decisions can be made. This PR refactors the dictionary appropriately to do so.