### PR TITLE
Refactor Dictionary/Word interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ cache: bundler
 rvm:
   - 2.2
   - jruby-9000
-bundler_args: --without development

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ cache: bundler
 rvm:
   - 2.2
   - jruby-9000
+bundler_args: --without development

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,11 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-# Specify your gem's dependencies in markov-ahkoppel2.gemspec
+# Specify your gem"s dependencies in markov-ahkoppel2.gemspec
 gemspec
 
 group :development, :test do
-  gem 'byebug', platform: :mri
+  gem "byebug", platform: :mri
+  gem "tokeneyes", path: "../tokeneyes"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,10 @@ gemspec
 
 group :development, :test do
   gem "byebug", platform: :mri
-  gem "tokeneyes", path: "../tokeneyes"
+  # If you're developing both gems, use the local version of Tokeneyes
+  if File.exist?("../tokeneyes")
+    gem "tokeneyes", path: "../tokeneyes"
+  end
 end
 
 group :test do

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.3.0
+
+* Refactor Dictionary to provide access to entries, removing a lot of method duplication
+
 ## 0.2.9
 
 Internal refactors only, no new functionality.

--- a/lib/markovian/corpus/dictionary.rb
+++ b/lib/markovian/corpus/dictionary.rb
@@ -5,17 +5,9 @@ require 'markovian/corpus/dictionary_entry'
 module Markovian
   class Corpus
     class Dictionary
-      def push(key, word, direction: :forwards)
-        # Incoming we get a Tokeneyes::Word object
-        dictionary[key.to_s].push(word, direction: direction)
-      end
-
-      def next_word(key)
-        dictionary[key].next_word
-      end
-
-      def previous_word(key)
-        dictionary[key].previous_word
+      def [](key)
+        # Key could be a string or a Tokeneyes::Word object
+        dictionary[key.to_s]
       end
 
       def random_word

--- a/lib/markovian/version.rb
+++ b/lib/markovian/version.rb
@@ -1,3 +1,3 @@
 module Markovian
-  VERSION = "0.2.9"
+  VERSION = "0.3.0"
 end

--- a/spec/lib/corpus/chain_spec.rb
+++ b/spec/lib/corpus/chain_spec.rb
@@ -5,13 +5,11 @@ module Markovian
     RSpec.describe Chain do
       let(:chain) { Chain.new }
       let(:word) { Faker::Lorem.word }
+      let(:next_word) { Faker::Lorem.word }
       let(:previous_word) { Faker::Lorem.word }
-      # IMO we don't need to test the random sampling here, since Dictionary provides that
-      # functionality
       let(:phrase_association) { Faker::Lorem.word }
-      let(:word_association) { Faker::Lorem.word }
 
-      describe "#next_word/#lengthen" do
+      describe "#next_word" do
         it "returns no values when empty" do
           expect(chain.next_word(word)).to be_nil
         end
@@ -19,21 +17,21 @@ module Markovian
         context "when populated" do
           context "with a single-word match" do
             before :each do
-              chain.lengthen(word, next_word: word_association)
+              chain.lengthen(word, next_word: next_word)
             end
 
             it "returns the next word when looking up by word" do
-              expect(chain.next_word(word)).to eq(word_association)
+              expect(chain.next_word(word)).to eq(next_word)
             end
 
             it "returns the next word when looking up by phrase" do
-              expect(chain.next_word(word, previous_word: previous_word)).to eq(word_association)
+              expect(chain.next_word(word, previous_word: previous_word)).to eq(next_word)
             end
           end
 
           context "with a phrase match and a single word match" do
             before :each do
-              chain.lengthen(word, next_word: word_association)
+              chain.lengthen(word, next_word: next_word)
               chain.lengthen(word, previous_word: previous_word, next_word: phrase_association)
             end
 
@@ -42,11 +40,11 @@ module Markovian
               # hard-code two results
               if RUBY_PLATFORM == "java"
                 results = [
-                  word_association, phrase_association, phrase_association, word_association, phrase_association, word_association, word_association
+                  next_word, phrase_association, phrase_association, next_word, phrase_association, next_word, next_word
                 ]
               else
                 results = [
-                  word_association, phrase_association, phrase_association, word_association, word_association, word_association, phrase_association
+                  next_word, phrase_association, phrase_association, next_word, next_word, next_word, phrase_association
                 ]
               end
               expect(7.times.map { chain.next_word(word) }).to eq(results)
@@ -75,12 +73,12 @@ module Markovian
 
       describe "#random_word" do
         it "asks the one-key dictionary for a random word", temporary_srand: 35 do
-          chain.lengthen(word, next_word: word_association)
-          chain.lengthen(word_association, next_word: word)
+          chain.lengthen(word, next_word: next_word)
+          chain.lengthen(next_word, next_word: word)
           if RUBY_PLATFORM == "java"
-            expect(3.times.map { chain.random_word }).to eq([word, word, word_association])
+            expect(3.times.map { chain.random_word }).to eq([word, word, next_word])
           else
-            expect(3.times.map { chain.random_word }).to eq([word, word_association, word_association])
+            expect(3.times.map { chain.random_word }).to eq([word, next_word, next_word])
           end
         end
       end
@@ -89,25 +87,25 @@ module Markovian
         let(:other_chain) { Chain.new }
 
         it "returns true if they're the same" do
-          chain.lengthen(word, next_word: word_association)
-          chain.lengthen(word_association, next_word: word)
-          other_chain.lengthen(word, next_word: word_association)
-          other_chain.lengthen(word_association, next_word: word)
+          chain.lengthen(word, next_word: next_word)
+          chain.lengthen(next_word, next_word: word)
+          other_chain.lengthen(word, next_word: next_word)
+          other_chain.lengthen(next_word, next_word: word)
           expect(chain).to eq(other_chain)
         end
 
         it "is order agnostic" do
-          chain.lengthen(word, next_word: word_association)
-          chain.lengthen(word_association, next_word: word)
-          other_chain.lengthen(word_association, next_word: word)
-          other_chain.lengthen(word, next_word: word_association)
+          chain.lengthen(word, next_word: next_word)
+          chain.lengthen(next_word, next_word: word)
+          other_chain.lengthen(next_word, next_word: word)
+          other_chain.lengthen(word, next_word: next_word)
           expect(chain).to eq(other_chain)
         end
 
         it "returns false if they're not the same " do
-          chain.lengthen(word, next_word: word_association)
-          chain.lengthen(word_association, next_word: word)
-          other_chain.lengthen(word, next_word: word_association)
+          chain.lengthen(word, next_word: next_word)
+          chain.lengthen(next_word, next_word: word)
+          other_chain.lengthen(word, next_word: next_word)
           expect(chain).not_to eq(other_chain)
         end
       end

--- a/spec/lib/corpus/dictionary_entry_spec.rb
+++ b/spec/lib/corpus/dictionary_entry_spec.rb
@@ -110,7 +110,7 @@ module Markovian
             entry.push(other_word, direction: :backwards)
             other_entry = DictionaryEntry.new(word)
             other_entry.push(next_word)
-            other_entry.push(Faker::Lorem.word, direction: :backwards)
+            other_entry.push(other_word + "foo", direction: :backwards)
             expect(entry).not_to eq(other_entry)
           end
         end

--- a/spec/lib/corpus/dictionary_spec.rb
+++ b/spec/lib/corpus/dictionary_spec.rb
@@ -9,45 +9,25 @@ module Markovian
         let(:word) { Faker::Lorem.word }
         let(:word2) { Faker::Lorem.word }
 
-        describe "next_word" do
-          it "pushes a word to the appropriate dictionary entry (forwards default)" do
-            expect_any_instance_of(DictionaryEntry).to receive(:push).with(word2, direction: :forwards) do |entry|
-              expect(entry.word).to eq(word)
-            end
-            dictionary.push(word, word2)
+        describe "#[]" do
+          it "returns an empty word entry if it doesn't exist yet" do
+            expect(dictionary[word]).to eq(DictionaryEntry.new(word))
           end
 
-          it "will push backwards if specified" do
-            expect_any_instance_of(DictionaryEntry).to receive(:push).with(word2, direction: :backwards) do |entry|
-              expect(entry.word).to eq(word)
-            end
-            dictionary.push(word, word2, direction: :backwards)
-          end
-        end
-
-        describe "#next_word" do
-          it "gets an appropriate word", temporary_srand: 21 do
-            dictionary.push(phrase, word)
-            dictionary.push(phrase, word2)
-            result = RUBY_PLATFORM == "java" ? [word, word, word2] : [word, word2, word]
-            expect(3.times.map { dictionary.next_word(phrase)}).to eq(result)
-          end
-        end
-
-        describe "#previous_word" do
-          it "gets an appropriate word", temporary_srand: 21 do
-            dictionary.push(phrase, word, direction: :backwards)
-            dictionary.push(phrase, word2, direction: :backwards)
-            result = RUBY_PLATFORM == "java" ? [word, word, word2] : [word, word2, word]
-            expect(3.times.map { dictionary.previous_word(phrase)}).to eq(result)
+          it "returns the existing entry if it exists" do
+            entry = dictionary[word]
+            entry.push(word2)
+            other_entry = DictionaryEntry.new(word)
+            other_entry.push(word2)
+            expect(dictionary[word]).to eq(other_entry)
           end
         end
 
         describe "#random_word" do
           it "gets a random word from the dictionary", temporary_srand: 20 do
-            dictionary.push(phrase, word)
-            dictionary.push(word, word2)
-            expect(3.times.map { dictionary.random_word }).to eq([word, phrase, word])
+            dictionary[phrase]
+            dictionary[word]
+            expect(3.times.map { dictionary.random_word }).to eq([phrase, word, phrase])
           end
         end
 
@@ -55,33 +35,33 @@ module Markovian
           let(:other_dictionary) { Dictionary.new }
 
           it "returns true if they're both the same" do
-            dictionary.push(phrase, word)
-            dictionary.push(word, word2)
-            other_dictionary.push(phrase, word)
-            other_dictionary.push(word, word2)
+            dictionary[phrase].push(word)
+            dictionary[word].push(word2)
+            other_dictionary[phrase].push(word)
+            other_dictionary[word].push(word2)
             expect(dictionary).to eq(other_dictionary)
           end
 
           it "is order agnostic" do
-            dictionary.push(phrase, word)
-            dictionary.push(word, word2)
-            other_dictionary.push(word, word2)
-            other_dictionary.push(phrase, word)
+            dictionary[phrase].push(word)
+            dictionary[word].push(word2)
+            other_dictionary[word].push(word2)
+            other_dictionary[phrase].push(word)
             expect(dictionary).to eq(other_dictionary)
           end
 
           it "returns false if they're not both the same" do
-            dictionary.push(phrase, word)
-            dictionary.push(word, word2)
-            other_dictionary.push(phrase, word)
+            dictionary[phrase].push(word)
+            dictionary[word].push(word2)
+            other_dictionary[phrase].push(word)
             expect(dictionary).not_to eq(other_dictionary)
           end
         end
 
         describe "#inspect" do
           it "contains the entry count rather than the dictionary" do
-            dictionary.push(phrase, word)
-            dictionary.push(word, word2)
+            dictionary[phrase].push(word)
+            dictionary[word].push(word2)
             expect(dictionary.inspect).to include("2 entries")
             expect(dictionary.inspect).not_to include(phrase)
             expect(dictionary.inspect).not_to include(word)

--- a/spec/lib/corpus_spec.rb
+++ b/spec/lib/corpus_spec.rb
@@ -40,7 +40,6 @@ module Markovian
       end
     end
 
-
     describe "#==" do
       let(:other_corpus) { Corpus.new }
       let(:word) { Faker::Lorem.word }


### PR DESCRIPTION
Previously, the Dictionary provided the interface to all data stored in the DictionaryEntry -- next_word, previous_word, etc. This resulted in a lot of method duplication up the chain (har har) of classes and would have made it hard to implement logic that relies on metadata in the DictionaryEntry.

This pull request refactors the Dictionary and DictionaryEntry -- the former now provides direct lookup to the latter, which can be used however is needed (as you'll see in later pull requests).