### PR TITLE
Refactor classes to improve metadata

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## 0.3.0
 
+* TextBuilder#construct now includes seed text by default (instead of via opt-in)
+* Add Chain#word_entry to allow access to word data
+* Properly collect metadata about words (previously collected next_word's data)
 * Refactor Dictionary to provide access to entries, removing a lot of method duplication
 
 ## 0.2.9

--- a/lib/markovian/corpus/chain.rb
+++ b/lib/markovian/corpus/chain.rb
@@ -1,5 +1,4 @@
 require 'markovian/corpus/dictionary'
-require 'markovian/text_builder/end_of_sentence_filter'
 
 # The Chain represents Markov info as it's being assembled or expanded from a text. To compensate
 # for small sample sizes, we track multiple chains (derived from both two-word phrases and single

--- a/lib/markovian/corpus/chain.rb
+++ b/lib/markovian/corpus/chain.rb
@@ -11,6 +11,12 @@ module Markovian
         @two_key_dictionary = Dictionary.new
       end
 
+      # Allow access to a word's metadata by providing its dictionary entry. For now, we only do
+      # individual words, not two-word phrases.
+      def word_entry(word)
+        @one_key_dictionary[word]
+      end
+
       def lengthen(word, next_word:, previous_word: nil)
         # When we encounter a word, we track its metadata and and what words surround it
         write_to_dictionary(@one_key_dictionary, word, word, next_word)

--- a/lib/markovian/corpus/chain.rb
+++ b/lib/markovian/corpus/chain.rb
@@ -1,4 +1,5 @@
 require 'markovian/corpus/dictionary'
+require 'markovian/text_builder/end_of_sentence_filter'
 
 # The Chain represents Markov info as it's being assembled or expanded from a text. To compensate
 # for small sample sizes, we track multiple chains (derived from both two-word phrases and single
@@ -58,7 +59,7 @@ module Markovian
       def entry_if_present(entry)
         # Ignore empty entries that haven't actually been seen in the corpus
         # TODO refactor to not even create them
-        entry if entry.count > 0
+        entry if entry.occurrences > 0
       end
 
       # We represent the two words as a space-delimited phrase for simplicity and speed of access via

--- a/lib/markovian/corpus/chain.rb
+++ b/lib/markovian/corpus/chain.rb
@@ -12,8 +12,9 @@ module Markovian
       end
 
       def lengthen(word, next_word:, previous_word: nil)
-        @one_key_dictionary[word].push(next_word)
-        @two_key_dictionary[two_word_key(previous_word, word)].push(next_word)
+        # When we encounter a word, we track its metadata and and what words surround it
+        write_to_dictionary(@one_key_dictionary, word, word, next_word)
+        write_to_dictionary(@two_key_dictionary, two_word_key(previous_word, word), word, next_word)
         word
       end
 
@@ -65,6 +66,11 @@ module Markovian
       # hash keys.
       def two_word_key(word1, word2)
         "#{word1} #{word2}"
+      end
+
+      def write_to_dictionary(dictionary, key, word_instance, next_word)
+        dictionary[key].record_observance(word_instance)
+        dictionary[key].push(next_word)
       end
     end
   end

--- a/lib/markovian/corpus/dictionary_entry.rb
+++ b/lib/markovian/corpus/dictionary_entry.rb
@@ -1,6 +1,9 @@
 module Markovian
   class Corpus
     class DictionaryEntry
+      # Below this, we don't have enough occurrences to draw conclusions about how a word is used.
+      SIGNIFICANT_OCCURRENCE_THRESHOLD = 50
+
       attr_reader :word, :counts
       def initialize(word)
         @word = word
@@ -37,6 +40,13 @@ module Markovian
 
       def occurrences
         counts[:total]
+      end
+
+      def likelihood_to_end_sentence
+        # if we don't have enough data, we don't have enough data
+        if occurrences >= SIGNIFICANT_OCCURRENCE_THRESHOLD
+          counts[:ends_sentence].to_f / occurrences
+        end
       end
 
       protected

--- a/lib/markovian/corpus/dictionary_entry.rb
+++ b/lib/markovian/corpus/dictionary_entry.rb
@@ -1,27 +1,29 @@
 module Markovian
   class Corpus
     class DictionaryEntry
-      # Below this, we don't have enough occurrences to draw conclusions about how a word is used.
-      SIGNIFICANT_OCCURRENCE_THRESHOLD = 50
-
       attr_reader :word, :counts
       def initialize(word)
-        @word = word
+        @word = word.to_s
         @next_words = []
         @previous_words = []
         @counts = Hash.new(0)
       end
 
-      def push(word, direction: :forwards)
-        # The incoming word will be a Tokeneyes::Word object
-        array_for_direction(direction) << word.to_s
-        # we don't want to double-count words if we read the text both forward and backward, so
+      def record_observance(word_instance, direction: :forwards)
+        # The word has been observed, so let's increase the appropriate counts.
+        # We don't want to double-count words if we read the text both forward and backward, so
         # only count in the forward direction. (If we encounter a scenario where someone only wants
         # to read in the backward direction, we can deal with that then.)
+        validate_direction(direction)
         if direction == :forwards
           @counts[:total] += 1
-          @counts[:ends_sentence] += 1 if word.ends_sentence?
+          @counts[:ends_sentence] += 1 if word_instance.ends_sentence?
         end
+      end
+
+      def push(next_word, direction: :forwards)
+        # Also add the follwoing word
+        array_for_direction(direction) << next_word.to_s
       end
 
       def next_word
@@ -40,13 +42,6 @@ module Markovian
 
       def occurrences
         counts[:total]
-      end
-
-      def likelihood_to_end_sentence
-        # if we don't have enough data, we don't have enough data
-        if occurrences >= SIGNIFICANT_OCCURRENCE_THRESHOLD
-          counts[:ends_sentence].to_f / occurrences
-        end
       end
 
       protected

--- a/lib/markovian/corpus/dictionary_entry.rb
+++ b/lib/markovian/corpus/dictionary_entry.rb
@@ -1,12 +1,12 @@
 module Markovian
   class Corpus
     class DictionaryEntry
-      attr_reader :word, :count
+      attr_reader :word, :counts
       def initialize(word)
         @word = word
         @next_words = []
         @previous_words = []
-        @count = 0
+        @counts = Hash.new(0)
       end
 
       def push(word, direction: :forwards)
@@ -15,7 +15,10 @@ module Markovian
         # we don't want to double-count words if we read the text both forward and backward, so
         # only count in the forward direction. (If we encounter a scenario where someone only wants
         # to read in the backward direction, we can deal with that then.)
-        @count += 1 if direction == :forwards
+        if direction == :forwards
+          @counts[:total] += 1
+          @counts[:ends_sentence] += 1 if word.ends_sentence?
+        end
       end
 
       def next_word
@@ -32,9 +35,13 @@ module Markovian
           self.previous_words == other.previous_words
       end
 
+      def occurrences
+        counts[:total]
+      end
+
       protected
 
-      # for equality checking
+      # for equality checking and other usage
       attr_reader :next_words, :previous_words
 
       VALID_DIRECTIONS = [:backwards, :forwards]

--- a/lib/markovian/text_builder.rb
+++ b/lib/markovian/text_builder.rb
@@ -61,6 +61,5 @@ module Markovian
       # We get back Tokeneyes::Word objects, but for now only care about the strings within
       Utils::TextSplitter.new(seed_text).components
     end
-    end
   end
 end

--- a/lib/markovian/text_builder.rb
+++ b/lib/markovian/text_builder.rb
@@ -12,16 +12,18 @@ module Markovian
     def construct(seed_text, length: 140, exclude_seed_text: false)
       # TODO: if we don't hit a result for the first pair, move backward through the original text
       # until we get something
-      seed_pair = identify_starter_text(seed_text)
-      result_with_next_word(
-        previous_pair: seed_pair,
-        result: exclude_seed_text ? nil : seed_text,
+      seed_components = split_seed_text(seed_text)
+      result_array = result_with_next_word(
+        previous_pair: identify_starter_text(seed_components),
+        result: exclude_seed_text ? [] : seed_components,
         length: length
       )
+      format_result_array(result_array)
     end
 
-    def identify_starter_text(raw_text)
-      seed_components = split_seed_text(raw_text)
+    protected
+
+    def identify_starter_text(seed_components)
       if seed_components.length >= 2
         seed_components[-2..-1]
       else
@@ -30,15 +32,13 @@ module Markovian
       end
     end
 
-    protected
-
     def result_with_next_word(previous_pair:, result:, length:)
       previous_word, current_word = previous_pair
       if next_word = corpus.next_word(current_word, previous_word: previous_word)
         # we use join rather than + to avoid leading spaces, and strip to ignore leading nils or
         # empty strings
-        interim_result = format_result_array([result, next_word])
-        if interim_result.length > length
+        interim_result = result + [next_word]
+        if format_result_array(interim_result).length > length
           result
         else
           result_with_next_word(
@@ -52,14 +52,15 @@ module Markovian
       end
     end
 
-    # Turn an array of words into an ongoing string
+    # Turn an array of Word objects into an ongoing string
     def format_result_array(array_of_words)
-      array_of_words.compact.map(&:strip).join(" ")
+      array_of_words.compact.map(&:to_s).map(&:strip).join(" ")
     end
 
     def split_seed_text(seed_text)
       # We get back Tokeneyes::Word objects, but for now only care about the strings within
-      Utils::TextSplitter.new(seed_text).components.map(&:to_s)
+      Utils::TextSplitter.new(seed_text).components
+    end
     end
   end
 end

--- a/lib/markovian/text_builder.rb
+++ b/lib/markovian/text_builder.rb
@@ -9,13 +9,13 @@ module Markovian
       @corpus = corpus
     end
 
-    def construct(seed_text, length: 140, start_result_with_seed: false)
+    def construct(seed_text, length: 140, exclude_seed_text: false)
       # TODO: if we don't hit a result for the first pair, move backward through the original text
       # until we get something
       seed_pair = identify_starter_text(seed_text)
       result_with_next_word(
         previous_pair: seed_pair,
-        result: start_result_with_seed ? seed_text : nil,
+        result: exclude_seed_text ? nil : seed_text,
         length: length
       )
     end

--- a/spec/lib/corpus/chain_spec.rb
+++ b/spec/lib/corpus/chain_spec.rb
@@ -27,6 +27,11 @@ module Markovian
             it "returns the next word when looking up by phrase" do
               expect(chain.next_word(word, previous_word: previous_word)).to eq(next_word.to_s)
             end
+
+            it "populates the the entry's data" do
+              chain.next_word(word, previous_word: previous_word)
+              expect(chain.word_entry(word).occurrences).to eq(1)
+            end
           end
 
           context "with a phrase match and a single word match" do

--- a/spec/lib/corpus/chain_spec.rb
+++ b/spec/lib/corpus/chain_spec.rb
@@ -87,7 +87,7 @@ module Markovian
           chain.lengthen(word, next_word: next_word)
           chain.lengthen(next_word, next_word: word)
           if RUBY_PLATFORM == "java"
-            expect(3.times.map { chain.random_word }).to eq([word, word, next_word].to_s)
+            expect(3.times.map { chain.random_word }).to eq([word, word, next_word].map(&:to_s))
           else
             expect(3.times.map { chain.random_word }).to eq([word, next_word, next_word].map(&:to_s))
           end

--- a/spec/lib/corpus/chain_spec.rb
+++ b/spec/lib/corpus/chain_spec.rb
@@ -9,6 +9,12 @@ module Markovian
       let(:previous_word) { Tokeneyes::Word.new(Faker::Lorem.word) }
       let(:phrase_association) { Tokeneyes::Word.new(Faker::Lorem.word) }
 
+      describe "#word_entry" do
+        it "returns the dictionary entry for the word" do
+          expect(chain.word_entry(word)).to eq(DictionaryEntry.new(word))
+        end
+      end
+
       describe "#next_word" do
         it "returns no values when empty" do
           expect(chain.next_word(word)).to be_nil

--- a/spec/lib/corpus/chain_spec.rb
+++ b/spec/lib/corpus/chain_spec.rb
@@ -4,10 +4,10 @@ module Markovian
   class Corpus
     RSpec.describe Chain do
       let(:chain) { Chain.new }
-      let(:word) { Faker::Lorem.word }
-      let(:next_word) { Faker::Lorem.word }
-      let(:previous_word) { Faker::Lorem.word }
-      let(:phrase_association) { Faker::Lorem.word }
+      let(:word) { Tokeneyes::Word.new(Faker::Lorem.word) }
+      let(:next_word) { Tokeneyes::Word.new(Faker::Lorem.word) }
+      let(:previous_word) { Tokeneyes::Word.new(Faker::Lorem.word) }
+      let(:phrase_association) { Tokeneyes::Word.new(Faker::Lorem.word) }
 
       describe "#next_word" do
         it "returns no values when empty" do
@@ -21,11 +21,11 @@ module Markovian
             end
 
             it "returns the next word when looking up by word" do
-              expect(chain.next_word(word)).to eq(next_word)
+              expect(chain.next_word(word)).to eq(next_word.to_s)
             end
 
             it "returns the next word when looking up by phrase" do
-              expect(chain.next_word(word, previous_word: previous_word)).to eq(next_word)
+              expect(chain.next_word(word, previous_word: previous_word)).to eq(next_word.to_s)
             end
           end
 
@@ -47,11 +47,11 @@ module Markovian
                   next_word, phrase_association, phrase_association, next_word, next_word, next_word, phrase_association
                 ]
               end
-              expect(7.times.map { chain.next_word(word) }).to eq(results)
+              expect(7.times.map { chain.next_word(word) }).to eq(results.map(&:to_s))
             end
 
             it "returns only the next match when looking up by phrase" do
-              expect(7.times.map { chain.next_word(word, previous_word: previous_word) }).to eq([phrase_association] * 7)
+              expect(7.times.map { chain.next_word(word, previous_word: previous_word) }).to eq([phrase_association.to_s] * 7)
             end
           end
 
@@ -61,11 +61,11 @@ module Markovian
             end
 
             it "returns only the next phrase match when looking up by word" do
-              expect(7.times.map { chain.next_word(word) }).to eq([phrase_association] * 7)
+              expect(7.times.map { chain.next_word(word) }).to eq([phrase_association.to_s] * 7)
             end
 
             it "returns only the next match when looking up by phrase" do
-              expect(7.times.map { chain.next_word(word, previous_word: previous_word) }).to eq([phrase_association] * 7)
+              expect(7.times.map { chain.next_word(word, previous_word: previous_word) }).to eq([phrase_association.to_s] * 7)
             end
           end
         end
@@ -76,9 +76,9 @@ module Markovian
           chain.lengthen(word, next_word: next_word)
           chain.lengthen(next_word, next_word: word)
           if RUBY_PLATFORM == "java"
-            expect(3.times.map { chain.random_word }).to eq([word, word, next_word])
+            expect(3.times.map { chain.random_word }).to eq([word, word, next_word].to_s)
           else
-            expect(3.times.map { chain.random_word }).to eq([word, next_word, next_word])
+            expect(3.times.map { chain.random_word }).to eq([word, next_word, next_word].map(&:to_s))
           end
         end
       end
@@ -102,7 +102,7 @@ module Markovian
           expect(chain).to eq(other_chain)
         end
 
-        it "returns false if they're not the same " do
+        it "returns false if they're not the same" do
           chain.lengthen(word, next_word: next_word)
           chain.lengthen(next_word, next_word: word)
           other_chain.lengthen(word, next_word: next_word)

--- a/spec/lib/corpus/dictionary_entry_spec.rb
+++ b/spec/lib/corpus/dictionary_entry_spec.rb
@@ -5,12 +5,45 @@ module Markovian
     class Chain
       RSpec.describe DictionaryEntry do
         let(:word) { Faker::Lorem.word }
+        let(:word_object) { Tokeneyes::Word.new(word) }
         let(:entry) { DictionaryEntry.new(word) }
         let(:next_word) { Tokeneyes::Word.new(Faker::Lorem.word) }
         let(:other_word) { Tokeneyes::Word.new(Faker::Lorem.word) }
 
         it "initializes the occurrences to 0" do
           expect(entry.occurrences).to eq(0)
+        end
+
+        describe "#record_observance" do
+          it "raises an error if the direction is invalid" do
+            expect { entry.push(word_object, direction: :sideways) }.to raise_exception(ArgumentError)
+          end
+
+          context "going forward (the default)" do
+            it "increases the occurence count" do
+              expect { 3.times { entry.record_observance(word_object) } }.to change { entry.occurrences }.from(0).to(3)
+            end
+
+            it "increases the ends_sentence count if appropriate" do
+              entry.record_observance(word_object)
+              word_object.ends_sentence = true
+              entry.record_observance(word_object)
+              expect(entry.counts[:ends_sentence]).to eq(1)
+            end
+          end
+
+          context "going backward" do
+            it "doesn't increase the seen count" do
+              expect { 3.times { entry.record_observance(word_object, direction: :backwards) } }.not_to change { entry.occurrences }
+            end
+
+            it "doesn't increase the ends_sentence count" do
+              entry.record_observance(word_object, direction: :backwards)
+              word_object.ends_sentence = true
+              entry.record_observance(word_object, direction: :backwards)
+              expect(entry.counts[:ends_sentence]).to eq(0)
+            end
+          end
         end
 
         describe "pushing and retrieving words" do
@@ -28,17 +61,6 @@ module Markovian
             it "doesn't populate the previous entries" do
               entry.push(next_word)
               expect(entry.previous_word).to be_nil
-            end
-
-            it "increases the occurence count" do
-              expect { 3.times { entry.push(next_word) } }.to change { entry.occurrences }.from(0).to(3)
-            end
-
-            it "increases the ends_sentence count if appropriate" do
-              entry.push(next_word)
-              next_word.ends_sentence = true
-              entry.push(next_word)
-              expect(entry.counts[:ends_sentence]).to eq(1)
             end
 
             it "samples from the entered words", temporary_srand: 17 do
@@ -64,17 +86,6 @@ module Markovian
             it "doesn't populate the forward entries" do
               entry.push(next_word, direction: :backwards)
               expect(entry.next_word).to be_nil
-            end
-
-            it "doesn't increase the seen count" do
-              expect { 3.times { entry.push(next_word, direction: :backwards) } }.not_to change { entry.occurrences }
-            end
-
-            it "doesn't increase the ends_sentence count" do
-              entry.push(next_word, direction: :backwards)
-              next_word.ends_sentence = true
-              entry.push(next_word, direction: :backwards)
-              expect(entry.counts[:ends_sentence]).to eq(0)
             end
 
             it "samples from the entered words", temporary_srand: 17 do
@@ -126,28 +137,6 @@ module Markovian
             other_entry.push(next_word)
             other_entry.push(Tokeneyes::Word.new(other_word.to_s + "foo"), direction: :backwards)
             expect(entry).not_to eq(other_entry)
-          end
-        end
-
-        describe "#likelihood_to_end_sentence" do
-          it "returns nil if it has too few entries" do
-            next_word.ends_sentence = true
-            (DictionaryEntry::SIGNIFICANT_OCCURRENCE_THRESHOLD - 1).times do
-              entry.push(next_word)
-            end
-            expect(entry.likelihood_to_end_sentence).to be_nil
-          end
-
-          it "returns % ending sentence if there's enough value" do
-            times_not_ending = (DictionaryEntry::SIGNIFICANT_OCCURRENCE_THRESHOLD * 0.4).to_i
-            times_not_ending.times do
-              entry.push(next_word)
-            end
-            next_word.ends_sentence = true
-            (DictionaryEntry::SIGNIFICANT_OCCURRENCE_THRESHOLD - times_not_ending).times do
-              entry.push(next_word)
-            end
-            expect(entry.likelihood_to_end_sentence).to eq(0.6)
           end
         end
       end

--- a/spec/lib/corpus/dictionary_entry_spec.rb
+++ b/spec/lib/corpus/dictionary_entry_spec.rb
@@ -128,6 +128,28 @@ module Markovian
             expect(entry).not_to eq(other_entry)
           end
         end
+
+        describe "#likelihood_to_end_sentence" do
+          it "returns nil if it has too few entries" do
+            next_word.ends_sentence = true
+            (DictionaryEntry::SIGNIFICANT_OCCURRENCE_THRESHOLD - 1).times do
+              entry.push(next_word)
+            end
+            expect(entry.likelihood_to_end_sentence).to be_nil
+          end
+
+          it "returns % ending sentence if there's enough value" do
+            times_not_ending = (DictionaryEntry::SIGNIFICANT_OCCURRENCE_THRESHOLD * 0.4).to_i
+            times_not_ending.times do
+              entry.push(next_word)
+            end
+            next_word.ends_sentence = true
+            (DictionaryEntry::SIGNIFICANT_OCCURRENCE_THRESHOLD - times_not_ending).times do
+              entry.push(next_word)
+            end
+            expect(entry.likelihood_to_end_sentence).to eq(0.6)
+          end
+        end
       end
     end
   end

--- a/spec/lib/corpus_spec.rb
+++ b/spec/lib/corpus_spec.rb
@@ -42,8 +42,8 @@ module Markovian
 
     describe "#==" do
       let(:other_corpus) { Corpus.new }
-      let(:word) { Faker::Lorem.word }
-      let(:other_word) { Faker::Lorem.word }
+      let(:word) { Tokeneyes::Word.new(Faker::Lorem.word) }
+      let(:other_word) { Tokeneyes::Word.new(Faker::Lorem.word) }
 
       it "returns true if they're both the same" do
         corpus.forward.lengthen(other_word, next_word: word)

--- a/spec/lib/text_builder_spec.rb
+++ b/spec/lib/text_builder_spec.rb
@@ -36,24 +36,24 @@ module Markovian
       end
 
       it "builds a text of the right length" do
-        expect(builder.construct(seed_text)).to eq("voluptate debitis rerum recusandae accusantium quo consequatur quam hic atque earum repellendus quasi est aut omnis eum numquam distinctio")
+        expect(builder.construct(seed_text)).to eq("going on voluptate debitis rerum recusandae accusantium quo consequatur quam hic atque earum repellendus quasi est aut omnis eum numquam")
       end
 
       it "accepts a shorter length" do
-        expect(builder.construct(seed_text, length: 20)).to eq("voluptate debitis")
+        expect(builder.construct(seed_text, length: 20)).to eq("going on voluptate")
       end
 
-      it "includes the original seed text if desired" do
-        expect(builder.construct("going! on?", start_result_with_seed: true)).to eq("going! on? voluptate debitis rerum recusandae accusantium quo consequatur quam hic atque earum repellendus quasi est aut omnis eum numquam")
+      it "excludes the original seed text if desired" do
+        expect(builder.construct("going! on?", exclude_seed_text: true)).to eq("voluptate debitis rerum recusandae accusantium quo consequatur quam hic atque earum repellendus quasi est aut omnis eum numquam distinctio")
       end
 
       it "ignores leading spaces" do
         stream_of_words[3] = " foo "
-        expect(builder.construct(seed_text)).to eq("voluptate foo rerum recusandae accusantium quo consequatur quam hic atque earum repellendus quasi est aut omnis eum numquam distinctio")
+        expect(builder.construct(seed_text)).to eq("going on voluptate foo rerum recusandae accusantium quo consequatur quam hic atque earum repellendus quasi est aut omnis eum numquam")
       end
 
       it "works fine if there's only one word in the seed text" do
-        expect(builder.construct("going")).to eq("on voluptate debitis rerum recusandae accusantium quo consequatur quam hic atque earum repellendus quasi est aut omnis eum numquam")
+        expect(builder.construct("going")).to eq("going on voluptate debitis rerum recusandae accusantium quo consequatur quam hic atque earum repellendus quasi est aut omnis eum numquam")
       end
     end
 

--- a/spec/lib/text_builder_spec.rb
+++ b/spec/lib/text_builder_spec.rb
@@ -17,18 +17,18 @@ module Markovian
 
       before :each do
         # freeze randomness
-        # jruby on travis has some weirdness around the keyword arg, so we treat is as a hash in
+        # jruby on travis has some weirdness around the keyword arg, so we treat it as a hash in
         # the tests
         allow(corpus).to receive(:next_word) do |current_word, params = {}|
           # simple mechanism to the next word
           previous_word = params[:previous_word]
-          if current_index = stream_of_words.index(current_word)
+          if current_index = stream_of_words.index(current_word.to_s)
             # since the stream is purely linear, we can also ensure that we're calling the words in
             # the right sequence
             if current_index == 0
               expect(previous_word).to be_nil
             else
-              expect(previous_word).to eq(stream_of_words[current_index - 1])
+              expect(previous_word.to_s).to eq(stream_of_words[current_index - 1])
             end
           end
           stream_of_words[current_index.to_i + 1]
@@ -54,20 +54,6 @@ module Markovian
 
       it "works fine if there's only one word in the seed text" do
         expect(builder.construct("going")).to eq("going on voluptate debitis rerum recusandae accusantium quo consequatur quam hic atque earum repellendus quasi est aut omnis eum numquam")
-      end
-    end
-
-    describe "#identify_starter_text" do
-      context "if the seed has multiple words" do
-        it "returns the last two items" do
-          expect(builder.identify_starter_text(seed_text)).to eq(["going", "on"])
-        end
-      end
-
-      context "if the seed is only one word" do
-        it "returns [nil, the_word]" do
-          expect(builder.identify_starter_text("result ")).to eq([nil, "result"])
-        end
       end
     end
   end


### PR DESCRIPTION
The original metadata implementation had a big mistake: when we tracked a word/next_word pair, it recorded the metadata for the _next_ word rather than the current word. That wasn't a big deal when it was just count (the result was the same) but now that we also track the number of times a word ends a sentence, that matters.

This pull request fixes that and also makes other improvements to Chain (provide DictionaryEntry access) and TextBuilder (seed text is included by default #unrelatedfix).