### PR TITLE
Add End of Sentence filter to strip unlikely final words

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ Fuller documentation will come shortly. For now, let's see how we can use Markov
 
 Exactly!
 
+## Features
+
+So far, Markovian gives you the ability to, given a set of inputs, generate random text. In
+addition, your money gets you:
+
+* A built-in importer to turn Twitter csv archives into Markov chain-derived text
+* A built-in filter  to remove final words that statistically (in the corpus) rarely end sentences.
+  Avoid unsightly sentences ending in "and so of" and so on!
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0
 
+* TextBuilder now filters out final words that statistically rarely end sentences (first filter!)
 * TextBuilder#construct now includes seed text by default (instead of via opt-in)
 * Add Chain#word_entry to allow access to word data
 * Properly collect metadata about words (previously collected next_word's data)

--- a/lib/markovian/chain/dictionary_entry.rb
+++ b/lib/markovian/chain/dictionary_entry.rb
@@ -54,6 +54,10 @@ module Markovian
         end
       end
 
+      def to_s
+        word
+      end
+
       protected
 
       # for equality checking and other usage

--- a/lib/markovian/chain/dictionary_entry.rb
+++ b/lib/markovian/chain/dictionary_entry.rb
@@ -1,6 +1,9 @@
 module Markovian
   class Chain
     class DictionaryEntry
+      # Below this, we don't have enough occurrences to draw conclusions about how a word is used.
+      SIGNIFICANT_OCCURRENCE_THRESHOLD = 50
+
       attr_reader :word, :counts
       def initialize(word)
         @word = word.to_s
@@ -42,6 +45,13 @@ module Markovian
 
       def occurrences
         counts[:total]
+      end
+
+      def likelihood_to_end_sentence
+        # if we don't have enough data, we don't have enough data
+        if occurrences >= SIGNIFICANT_OCCURRENCE_THRESHOLD
+          counts[:ends_sentence].to_f / occurrences
+        end
       end
 
       protected

--- a/lib/markovian/text_builder.rb
+++ b/lib/markovian/text_builder.rb
@@ -1,4 +1,5 @@
 require 'markovian/utils/text_splitter'
+require 'markovian/text_builder/end_of_sentence_filter'
 
 # This class, given a Markov chain, will attempt to construct a new text based on a given seed using
 # the Markov associations.
@@ -13,15 +14,19 @@ module Markovian
       # TODO: if we don't hit a result for the first pair, move backward through the original text
       # until we get something
       seed_components = split_seed_text(seed_text)
-      result_array = result_with_next_word(
+      output = result_with_next_word(
         previous_pair: identify_starter_text(seed_components),
         result: exclude_seed_text ? [] : seed_components,
         length: length
       )
-      format_result_array(result_array)
+      format_output(apply_filters(output))
     end
 
     protected
+
+    def apply_filters(output)
+      EndOfSentenceFilter.new.filtered_sentence(sentence_with_word_data(output))
+    end
 
     def identify_starter_text(seed_components)
       if seed_components.length >= 2
@@ -38,7 +43,7 @@ module Markovian
         # we use join rather than + to avoid leading spaces, and strip to ignore leading nils or
         # empty strings
         interim_result = result + [next_word]
-        if format_result_array(interim_result).length > length
+        if format_output(interim_result).length > length
           result
         else
           result_with_next_word(
@@ -53,8 +58,12 @@ module Markovian
     end
 
     # Turn an array of Word objects into an ongoing string
-    def format_result_array(array_of_words)
+    def format_output(array_of_words)
       array_of_words.compact.map(&:to_s).map(&:strip).join(" ")
+    end
+
+    def sentence_with_word_data(sentence)
+      @sentence_with_word_data ||= sentence.map {|word| chain.word_entry(word)}
     end
 
     def split_seed_text(seed_text)

--- a/lib/markovian/text_builder/end_of_sentence_filter.rb
+++ b/lib/markovian/text_builder/end_of_sentence_filter.rb
@@ -1,0 +1,31 @@
+module Markovian
+  class TextBuilder
+    # This class will take sentence and apply appropriate filters. It will roll back a sentence up
+    # to a certain number of words if those words have a low likelihood of ending the sentence.
+    # Future changes will increase the qualities filtered for.
+    class EndOfSentenceFilter
+      MAX_WORDS_FILTERED = 3
+
+      def filtered_sentence(sentence)
+        filter_unlikely_ending_words(sentence)
+      end
+
+      protected
+
+      def filter_unlikely_ending_words(current_sentence, words_filtered = 0)
+        return current_sentence if words_filtered >= MAX_WORDS_FILTERED
+
+        last_word = current_sentence.last
+        likelihood = last_word.likelihood_to_end_sentence
+        if likelihood && rand < likelihood
+          # if we pop a word, consider removing the next one
+          filter_unlikely_ending_words(current_sentence[0..-2], words_filtered + 1)
+        else
+          # if this word hasn't been seen enough, allow it to end a sentence
+          current_sentence
+        end
+      end
+    end
+  end
+end
+

--- a/spec/markovian/chain/dictionary_entry_spec.rb
+++ b/spec/markovian/chain/dictionary_entry_spec.rb
@@ -160,6 +160,12 @@ module Markovian
           expect(entry.likelihood_to_end_sentence).to eq(0.6)
         end
       end
+
+      describe "#to_s" do
+        it "returns the word" do
+          expect(entry.to_s).to eq(word)
+        end
+      end
     end
   end
 end

--- a/spec/markovian/chain/dictionary_entry_spec.rb
+++ b/spec/markovian/chain/dictionary_entry_spec.rb
@@ -138,6 +138,28 @@ module Markovian
           expect(entry).not_to eq(other_entry)
         end
       end
+
+      describe "#likelihood_to_end_sentence" do
+        it "returns nil if it has too few entries" do
+          word_object.ends_sentence = true
+          (DictionaryEntry::SIGNIFICANT_OCCURRENCE_THRESHOLD - 1).times do
+            entry.record_observance(word_object)
+          end
+          expect(entry.likelihood_to_end_sentence).to be_nil
+        end
+
+        it "returns % ending sentence if there's enough value" do
+          times_not_ending = (DictionaryEntry::SIGNIFICANT_OCCURRENCE_THRESHOLD * 0.4).to_i
+          times_not_ending.times do
+            entry.record_observance(word_object)
+          end
+          word_object.ends_sentence = true
+          (DictionaryEntry::SIGNIFICANT_OCCURRENCE_THRESHOLD - times_not_ending).times do
+            entry.record_observance(word_object)
+          end
+          expect(entry.likelihood_to_end_sentence).to eq(0.6)
+        end
+      end
     end
   end
 end

--- a/spec/markovian/text_builder/end_of_sentence_filter_spec.rb
+++ b/spec/markovian/text_builder/end_of_sentence_filter_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+module Markovian
+  class TextBuilder
+    RSpec.describe EndOfSentenceFilter do
+      let(:filter) { EndOfSentenceFilter.new }
+
+      describe "#filtered_sentence" do
+        let(:raw_sentence) { 5.times.map { Faker::Lorem.word }  }
+        let(:sentence) { raw_sentence.map {|word| Chain::DictionaryEntry.new(word) } }
+        let(:significant_count) { Chain::DictionaryEntry::SIGNIFICANT_OCCURRENCE_THRESHOLD + 1 }
+
+        def mark_how_ends_sentence(word, ends_sentence = false, count = significant_count)
+          word_sighting = Tokeneyes::Word.new(word.word)
+          word_sighting.ends_sentence = ends_sentence
+          count.times do
+            word.record_observance(word_sighting)
+          end
+        end
+
+        it "does nothing to the sentence if the none of the last words have likelihoods" do
+          sentence[0..1].each do |word|
+            mark_how_ends_sentence(word, true)
+          end
+          expect(filter.filtered_sentence(sentence)).to eq(sentence)
+        end
+
+        it "does nothing if the words occur enough but don't end sentences" do
+          sentence.each do |word|
+            mark_how_ends_sentence(word)
+          end
+          expect(filter.filtered_sentence(sentence)).to eq(sentence)
+        end
+
+        it "will strip a words that never end sentences" do
+          sentence.each_with_index do |word, index|
+            mark_how_ends_sentence(word, index == 4)
+          end
+          expect(filter.filtered_sentence(sentence)).to eq(sentence[0..3])
+        end
+
+        it "will strip only up to three words" do
+          sentence.each do |word|
+            mark_how_ends_sentence(word, true)
+          end
+          expect(filter.filtered_sentence(sentence)).to eq(sentence[0..1])
+        end
+
+        it "applies a probability based on the word's likelihood to end the sentence", temporary_srand: 37 do
+          proportion = (significant_count * 0.6).to_i
+          mark_how_ends_sentence(sentence.last, true, proportion)
+          mark_how_ends_sentence(sentence.last, false, significant_count - proportion)
+          result = 10.times.map { filter.filtered_sentence(sentence)[4] }
+          last_word = sentence.last
+          if RUBY_PLATFORM == "java"
+            expect(result).to eq([last_word, nil, last_word, nil, last_word, last_word, last_word, nil, last_word, last_word])
+          else
+            expect(result).to eq([nil, last_word, last_word, nil, last_word, nil, last_word, last_word, last_word, nil])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/markovian/text_builder_spec.rb
+++ b/spec/markovian/text_builder_spec.rb
@@ -33,6 +33,10 @@ module Markovian
           end
           stream_of_words[current_index.to_i + 1]
         end
+
+        allow(chain).to receive(:word_entry) do |word|
+          Markovian::Chain::DictionaryEntry.new(word)
+        end
       end
 
       it "builds a text of the right length" do
@@ -54,6 +58,16 @@ module Markovian
 
       it "works fine if there's only one word in the seed text" do
         expect(builder.construct("going")).to eq("going on voluptate debitis rerum recusandae accusantium quo consequatur quam hic atque earum repellendus quasi est aut omnis eum numquam")
+      end
+
+      it "applies the filter" do
+        result = ["result", "words"]
+        expect_any_instance_of(TextBuilder::EndOfSentenceFilter).to receive(:filtered_sentence) do |instance, words|
+          expect(words.map(&:class).uniq).to eq([Chain::DictionaryEntry])
+          expect(words.map(&:word).join(" ")).to eq("going on voluptate debitis rerum recusandae accusantium quo consequatur quam hic atque earum repellendus quasi est aut omnis eum numquam")
+          result
+        end
+        expect(builder.construct("going")).to eq(result.join(" "))
       end
     end
   end


### PR DESCRIPTION
One problem with early Markovian texts was their tendency to end with particles and conjunctions -- words that occur frequently in English but that very rarely end sentences. You'd get a sentence like "s-bahn ring are often effective in getting from an alternate reality in which all", which just trails off abruptly when the character limit is reached.

This pull request adds an EndOfSentenceFilter, the first tool to use the metadata we collect when creating a Chain from a corpus of text. By looking at how frequently a word occurs against how frequently it occurs at the end of the sentence, we can then roll back words (up to three) that probably shouldn't be at the end of the text.