### PR TITLE
Sentence Builder

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## 0.4.0
 
+* Extract SentenceBuilder from TextBuilder for future use
 * Chain#lengthen can now take strings as well as Tokeneyes::Words
 * Fix bug preventing reuse of TextBuilder objects
 * EndOfSentenceFilter can now handle sentences where no word meets the criteria

--- a/lib/markovian/text_builder.rb
+++ b/lib/markovian/text_builder.rb
@@ -1,24 +1,19 @@
 require 'markovian/utils/text_splitter'
+require 'markovian/text_builder/sentence_builder'
 require 'markovian/text_builder/end_of_sentence_filter'
 
 # This class, given a Markov chain, will attempt to construct a new text based on a given seed using
 # the Markov associations.
 module Markovian
   class TextBuilder
-    attr_reader :seed_text, :chain
+    attr_reader :chain
     def initialize(chain)
       @chain = chain
     end
 
     def construct(seed_text, length: 140, exclude_seed_text: false)
-      # TODO: if we don't hit a result for the first pair, move backward through the original text
-      # until we get something
-      seed_components = split_seed_text(seed_text)
-      output = result_with_next_word(
-        previous_pair: identify_starter_text(seed_components),
-        result: exclude_seed_text ? [] : seed_components,
-        length: length
-      )
+      sentence_builder = SentenceBuilder.new(chain: chain, max_length: length, seed_text: seed_text)
+      output = sentence_builder.construct_sentence(exclude_seed_text)
       format_output(apply_filters(output))
     end
 
@@ -26,35 +21,6 @@ module Markovian
 
     def apply_filters(output)
       EndOfSentenceFilter.new.filtered_sentence(sentence_with_word_data(output))
-    end
-
-    def identify_starter_text(seed_components)
-      if seed_components.length >= 2
-        seed_components[-2..-1]
-      else
-        # if we only have a one-word seed text, the previous word is nil
-        [nil, seed_components.first]
-      end
-    end
-
-    def result_with_next_word(previous_pair:, result:, length:)
-      previous_word, current_word = previous_pair
-      if next_word = chain.next_word(current_word, previous_word: previous_word)
-        # we use join rather than + to avoid leading spaces, and strip to ignore leading nils or
-        # empty strings
-        interim_result = result + [next_word]
-        if format_output(interim_result).length > length
-          result
-        else
-          result_with_next_word(
-            previous_pair: [current_word, next_word],
-            result: interim_result,
-            length: length
-          )
-        end
-      else
-        result
-      end
     end
 
     # Turn an array of Word objects into an ongoing string
@@ -66,9 +32,8 @@ module Markovian
       sentence.map {|word| chain.word_entry(word)}
     end
 
-    def split_seed_text(seed_text)
-      # We get back Tokeneyes::Word objects, but for now only care about the strings within
-      Utils::TextSplitter.new(seed_text).components
+    def sentence_builder
+      @sentence_builder ||= SentenceBuilder.new(chain)
     end
   end
 end

--- a/lib/markovian/text_builder/sentence_builder.rb
+++ b/lib/markovian/text_builder/sentence_builder.rb
@@ -1,0 +1,63 @@
+module Markovian
+  class TextBuilder
+    class SentenceBuilder
+      attr_reader :seed_text, :chain, :max_length
+      def initialize(chain:, seed_text:, max_length:)
+        @chain = chain
+        @seed_text = seed_text
+        @max_length = max_length
+      end
+
+      def construct_sentence(exclude_seed_text = false)
+        seed_components = split_seed_text(seed_text)
+        result = result_with_next_word(
+          previous_pair: identify_starter_text(seed_components),
+          result: exclude_seed_text ? [] : seed_components
+        )
+        # Return a set of strings, not Tokeneyes::Word objects
+        result.map(&:to_s)
+      end
+
+      protected
+
+      def identify_starter_text(seed_components)
+        if seed_components.length >= 2
+          seed_components[-2..-1]
+        else
+          # if we only have a one-word seed text, the previous word is nil
+          [nil, seed_components.first]
+        end
+      end
+
+      def result_with_next_word(previous_pair:, result:)
+        previous_word, current_word = previous_pair
+        if next_word = chain.next_word(current_word, previous_word: previous_word)
+          # we use join rather than + to avoid leading spaces, and strip to ignore leading nils or
+          # empty strings
+          interim_result = result + [next_word]
+          if format_output(interim_result).length > max_length
+            result
+          else
+            result_with_next_word(
+              previous_pair: [current_word, next_word],
+              result: interim_result
+            )
+          end
+        else
+          result
+        end
+      end
+
+      def split_seed_text(seed_text)
+        # We get back Tokeneyes::Word objects, but for now only care about the strings within
+        Utils::TextSplitter.new(seed_text).components
+      end
+
+      # Turn an array of Word objects into an ongoing string
+      def format_output(array_of_words)
+        array_of_words.compact.map(&:to_s).map(&:strip).join(" ")
+      end
+    end
+  end
+end
+

--- a/spec/markovian/text_builder/sentence_builder_spec.rb
+++ b/spec/markovian/text_builder/sentence_builder_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+module Markovian
+  class TextBuilder
+    RSpec.describe SentenceBuilder do
+      let(:seed_text) { "going on" }
+      let(:chain) { double("Chain") }
+      let(:max_length) { 140 }
+      let(:builder) {
+        SentenceBuilder.new(chain: chain, seed_text: seed_text, max_length: max_length)
+      }
+
+      describe "#construct_sentence", temporary_srand: 17 do
+        let(:stream_of_words) {
+          [
+            "going", "on", "voluptate", "debitis", "rerum", "recusandae", "accusantium", "quo",
+            "consequatur", "quam", "hic", "atque", "earum", "repellendus", "quasi", "est", "aut",
+            "omnis", "eum", "numquam", "distinctio"
+          ]
+        }
+        let(:expected_result_at_default_length) { stream_of_words[0..-2] }
+
+        before :each do |example|
+          # freeze randomness
+          # jruby on travis has some weirdness around the keyword arg, so we treat it as a hash in
+          # the tests
+          skip_previous_word_validation = example.metadata[:skip_previous_word_validation]
+          allow(chain).to receive(:next_word) do |current_word, params = {}|
+            # simple mechanism to the next word
+            previous_word = params[:previous_word]
+          if current_index = stream_of_words.index(current_word.to_s)
+            # since the stream is purely linear, we can also ensure that we're calling the words in
+            # the right sequence
+            if skip_previous_word_validation
+              # do nothing
+            elsif current_index == 0
+              expect(previous_word).to be_nil
+            else
+              expect(previous_word.to_s).to eq(stream_of_words[current_index - 1])
+            end
+          end
+          stream_of_words[current_index.to_i + 1]
+          end
+
+          allow(chain).to receive(:word_entry) do |word|
+            Markovian::Chain::DictionaryEntry.new(word)
+          end
+        end
+
+        it "builds a text of the right length" do
+          expect(builder.construct_sentence.map(&:to_s)).to eq(expected_result_at_default_length)
+        end
+
+        it "ignores punctuation in the original seed text" do
+          builder = SentenceBuilder.new(chain: chain, seed_text: "going? on!", max_length: max_length)
+          expect(builder.construct_sentence).to eq(expected_result_at_default_length)
+        end
+
+        it "accepts a shorter length" do
+          shorter_builder = SentenceBuilder.new(chain: chain, seed_text: seed_text, max_length: 20)
+          expect(shorter_builder.construct_sentence).to eq(stream_of_words[0..2])
+        end
+
+        it "excludes the original seed text if desired" do
+          expect(builder.construct_sentence(true)).to eq(stream_of_words[2..-1])
+        end
+
+        it "ignores leading spaces" do
+          stream_of_words[3] = " foo "
+          expect(builder.construct_sentence).to eq(expected_result_at_default_length)
+        end
+
+        it "works fine if there's only one word in the seed text" do
+          builder_with_fewer_words = SentenceBuilder.new(chain: chain, seed_text: "going", max_length: max_length)
+          expect(builder_with_fewer_words.construct_sentence).to eq(stream_of_words[0..-2])
+        end
+      end
+    end
+  end
+end

--- a/spec/markovian/text_builder_spec.rb
+++ b/spec/markovian/text_builder_spec.rb
@@ -6,76 +6,46 @@ module Markovian
     let(:chain) { double("Chain") }
     let(:builder) { TextBuilder.new(chain) }
 
-    describe "#construct", temporary_srand: 17 do
-      let(:stream_of_words) {
-        [
-          "going", "on", "voluptate", "debitis", "rerum", "recusandae", "accusantium", "quo",
-          "consequatur", "quam", "hic", "atque", "earum", "repellendus", "quasi", "est", "aut",
-          "omnis", "eum", "numquam", "distinctio"
-        ]
-      }
+    describe "#construct" do
+      let(:results) { Faker::Lorem.words(5) }
+      let(:length) { 140 }
+      let(:exclude_seed_text) { false }
 
-      before :each do |example|
-        # freeze randomness
-        # jruby on travis has some weirdness around the keyword arg, so we treat it as a hash in
-        # the tests
-        skip_previous_word_validation = example.metadata[:skip_previous_word_validation]
-        allow(chain).to receive(:next_word) do |current_word, params = {}|
-          # simple mechanism to the next word
-          previous_word = params[:previous_word]
-          if current_index = stream_of_words.index(current_word.to_s)
-            # since the stream is purely linear, we can also ensure that we're calling the words in
-            # the right sequence
-            if skip_previous_word_validation
-              # do nothing
-            elsif current_index == 0
-              expect(previous_word).to be_nil
-            else
-              expect(previous_word.to_s).to eq(stream_of_words[current_index - 1])
-            end
-          end
-          stream_of_words[current_index.to_i + 1]
-        end
-
+      before :each do
         allow(chain).to receive(:word_entry) do |word|
-          Markovian::Chain::DictionaryEntry.new(word)
+          Chain::DictionaryEntry.new(word)
+        end
+
+        allow_any_instance_of(TextBuilder::SentenceBuilder).to receive(:construct_sentence) do |instance, exclude_seed_text|
+          expect(exclude_seed_text).to eq(exclude_seed_text)
+          expect(instance.chain).to eq(chain)
+          expect(instance.seed_text).to eq(seed_text)
+          expect(instance.max_length).to eq(length)
+          results
         end
       end
 
-      it "builds a text of the right length" do
-        expect(builder.construct(seed_text)).to eq("going on voluptate debitis rerum recusandae accusantium quo consequatur quam hic atque earum repellendus quasi est aut omnis eum numquam")
+      it "returns the results of the SentenceBuilder call joined together up to 140 characters" do
+        expect(builder.construct(seed_text)).to eq(results.join(" "))
       end
 
-      it "accepts a shorter length" do
-        expect(builder.construct(seed_text, length: 20)).to eq("going on voluptate")
-      end
+      context "with a different length" do
+        let(:length) { 30 }
 
-      it "excludes the original seed text if desired" do
-        expect(builder.construct("going! on?", exclude_seed_text: true)).to eq("voluptate debitis rerum recusandae accusantium quo consequatur quam hic atque earum repellendus quasi est aut omnis eum numquam distinctio")
-      end
-
-      it "ignores leading spaces" do
-        stream_of_words[3] = " foo "
-        expect(builder.construct(seed_text)).to eq("going on voluptate foo rerum recusandae accusantium quo consequatur quam hic atque earum repellendus quasi est aut omnis eum numquam")
-      end
-
-      it "works fine with if the same instance is called more than once", :skip_previous_word_validation do
-        builder.construct("going")
-        expect(builder.construct("on")).to eq("on voluptate debitis rerum recusandae accusantium quo consequatur quam hic atque earum repellendus quasi est aut omnis eum numquam")
-      end
-
-      it "works fine if there's only one word in the seed text" do
-        expect(builder.construct("going")).to eq("going on voluptate debitis rerum recusandae accusantium quo consequatur quam hic atque earum repellendus quasi est aut omnis eum numquam")
+        it "passes the other length through" do
+          # verify that the assertion in the before filter still passes
+          expect(builder.construct(seed_text, length: length)).to eq(results.join(" "))
+        end
       end
 
       it "applies the filter" do
-        result = ["result", "words"]
+        filter_result = ["result", "words"]
         expect_any_instance_of(TextBuilder::EndOfSentenceFilter).to receive(:filtered_sentence) do |instance, words|
           expect(words.map(&:class).uniq).to eq([Chain::DictionaryEntry])
-          expect(words.map(&:word).join(" ")).to eq("going on voluptate debitis rerum recusandae accusantium quo consequatur quam hic atque earum repellendus quasi est aut omnis eum numquam")
-          result
+          expect(words.map(&:word)).to eq(results)
+          filter_result
         end
-        expect(builder.construct("going")).to eq(result.join(" "))
+        expect(builder.construct(seed_text)).to eq(filter_result.join(" "))
       end
     end
   end


### PR DESCRIPTION
Ultimately we want to support building text with multiple sentences, with the sentence ends being determined by statistical probabilities in the original corpus. This diff pulls out the SentenceBuilder from the TextBuidler class -- right now nothing else has changed, but future pull requests will use this.