### PR TITLE
Fix Probabilities in EndOfSentenceFilter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,8 +5,7 @@
 * Extract SentenceBuilder from TextBuilder for future use
 * Chain#lengthen can now take strings as well as Tokeneyes::Words
 * Fix bug preventing reuse of TextBuilder objects
-* EndOfSentenceFilter can now handle sentences where no word meets the criteria
-* EndOfSentenceFilter now strips as many words as shouldn't be there
+* Update EndOfSentenceFilter (works when no words match, has no limit, uses proper probabilities)
 * Bumped up the significant occurrence threshold for filtering to 500 occurrences
 * Handle edge cases of words that always end sentences
 

--- a/lib/markovian/chain/dictionary_entry.rb
+++ b/lib/markovian/chain/dictionary_entry.rb
@@ -40,7 +40,8 @@ module Markovian
       end
 
       def ==(other)
-        self.word == other.word &&
+        other &&
+          self.word == other.word &&
           self.next_words == other.next_words &&
           self.previous_words == other.previous_words
       end

--- a/lib/markovian/text_builder/end_of_sentence_filter.rb
+++ b/lib/markovian/text_builder/end_of_sentence_filter.rb
@@ -34,7 +34,7 @@ module Markovian
         # c2) randomly fail a check based on how frequently they end stuff
         likelihood &&
           likelihood != 1 &&
-          (likelihood == 0 || rand < word.likelihood_to_end_sentence)
+          (likelihood == 0 || rand > word.likelihood_to_end_sentence)
 
       end
     end

--- a/spec/markovian/chain/dictionary_entry_spec.rb
+++ b/spec/markovian/chain/dictionary_entry_spec.rb
@@ -137,6 +137,10 @@ module Markovian
           other_entry.push(Tokeneyes::Word.new(other_word.to_s + "foo"), direction: :backwards)
           expect(entry).not_to eq(other_entry)
         end
+
+        it "is not equal to nil" do
+          expect(entry).not_to eq(nil)
+        end
       end
 
       describe "#likelihood_to_end_sentence" do

--- a/spec/markovian/text_builder/end_of_sentence_filter_spec.rb
+++ b/spec/markovian/text_builder/end_of_sentence_filter_spec.rb
@@ -46,9 +46,9 @@ module Markovian
           result = 10.times.map { filter.filtered_sentence(sentence)[4] }
           last_word = sentence.last
           if RUBY_PLATFORM == "java"
-            expect(result).to eq([last_word, nil, last_word, nil, last_word, last_word, last_word, nil, last_word, last_word])
+            expect(result).to eq([nil, last_word, nil, last_word, nil, nil, nil, last_word, nil, nil])
           else
-            expect(result).to eq([nil, last_word, last_word, nil, last_word, nil, last_word, last_word, last_word, nil])
+            expect(result).to eq([last_word, nil, nil, last_word, nil, last_word, nil, nil, nil, last_word])
           end
         end
       end


### PR DESCRIPTION
I managed to confuse myself with the EndOfSentenceFilter calculations; it should strip with `rand > likelihood_to_end_sentence`, not <. (That is, if a word only ends a sentence 5% of the time, it should be stripped 95% of the time.)