### PR TITLE
Remove backwards direction for dictionary compilation

### DIFF
--- a/lib/markovian/chain/dictionary_entry.rb
+++ b/lib/markovian/chain/dictionary_entry.rb
@@ -10,40 +10,28 @@ module Markovian
       def initialize(word)
         @word = word.to_s
         @next_words = []
-        @previous_words = []
         @counts = Hash.new(0)
       end
 
-      def record_observance(word_instance, direction: :forwards)
+      def record_observance(word_instance)
         # The word has been observed, so let's increase the appropriate counts.
-        # We don't want to double-count words if we read the text both forward and backward, so
-        # only count in the forward direction. (If we encounter a scenario where someone only wants
-        # to read in the backward direction, we can deal with that then.)
-        validate_direction(direction)
-        if direction == :forwards
-          @counts[:total] += 1
-          @counts[:ends_sentence] += 1 if word_instance.ends_sentence?
-        end
+        @counts[:total] += 1
+        @counts[:ends_sentence] += 1 if word_instance.ends_sentence?
       end
 
-      def push(next_word, direction: :forwards)
+      def push(next_word)
         # Also add the follwoing word
-        array_for_direction(direction) << next_word.to_s
+        @next_words << next_word.to_s
       end
 
       def next_word
         next_words.sample
       end
 
-      def previous_word
-        previous_words.sample
-      end
-
       def ==(other)
         other &&
           self.word == other.word &&
-          self.next_words == other.next_words &&
-          self.previous_words == other.previous_words
+          self.next_words == other.next_words
       end
 
       def occurrences
@@ -64,20 +52,7 @@ module Markovian
       protected
 
       # for equality checking and other usage
-      attr_reader :next_words, :previous_words
-
-      VALID_DIRECTIONS = [:backwards, :forwards]
-
-      def array_for_direction(direction)
-        validate_direction(direction)
-        direction == :backwards ? previous_words : next_words
-      end
-
-      def validate_direction(direction)
-        unless VALID_DIRECTIONS.include?(direction)
-          raise ArgumentError.new("Invalid direction #{direction.inspect}, valid directions are #{VALID_DIRECTIONS.inspect}")
-        end
-      end
+      attr_reader :next_words
     end
   end
 end

--- a/spec/markovian/chain/dictionary_entry_spec.rb
+++ b/spec/markovian/chain/dictionary_entry_spec.rb
@@ -15,126 +15,66 @@ module Markovian
 
       describe "#record_observance" do
         it "raises an error if the direction is invalid" do
-          expect { entry.push(word_object, direction: :sideways) }.to raise_exception(ArgumentError)
+          expect { entry.push(word_object) }
         end
 
-        context "going forward (the default)" do
-          it "increases the occurence count" do
-            expect { 3.times { entry.record_observance(word_object) } }.to change { entry.occurrences }.from(0).to(3)
-          end
-
-          it "increases the ends_sentence count if appropriate" do
-            entry.record_observance(word_object)
-            word_object.ends_sentence = true
-            entry.record_observance(word_object)
-            expect(entry.counts[:ends_sentence]).to eq(1)
-          end
+        it "increases the occurence count" do
+          expect { 3.times { entry.record_observance(word_object) } }.to change { entry.occurrences }.from(0).to(3)
         end
 
-        context "going backward" do
-          it "doesn't increase the seen count" do
-            expect { 3.times { entry.record_observance(word_object, direction: :backwards) } }.not_to change { entry.occurrences }
-          end
-
-          it "doesn't increase the ends_sentence count" do
-            entry.record_observance(word_object, direction: :backwards)
-            word_object.ends_sentence = true
-            entry.record_observance(word_object, direction: :backwards)
-            expect(entry.counts[:ends_sentence]).to eq(0)
-          end
+        it "increases the ends_sentence count if appropriate" do
+          entry.record_observance(word_object)
+          word_object.ends_sentence = true
+          entry.record_observance(word_object)
+          expect(entry.counts[:ends_sentence]).to eq(1)
         end
       end
 
       describe "pushing and retrieving words" do
-        it "raises an error if the direction is invalid" do
-          expect { entry.push(next_word, direction: :sideways) }.to raise_exception(ArgumentError)
+        it "returns the next word if desired" do
+          # since there's only one word it'll always return the same value
+          entry.push(next_word)
+          expect(entry.next_word).to eq(next_word.to_s)
         end
 
-        context "going forward (the default)" do
-          it "returns the next word if desired" do
-            # since there's only one word it'll always return the same value
-            entry.push(next_word)
-            expect(entry.next_word).to eq(next_word.to_s)
+        it "samples from the entered words", temporary_srand: 17 do
+          # fix the order of sampling so we can reproduce the test
+          entry.push(next_word)
+          entry.push(other_word)
+          if RUBY_PLATFORM == "java"
+            result = [next_word, other_word, other_word, other_word, other_word, next_word, next_word]
+          else
+            result = [next_word, next_word, other_word, next_word, other_word, next_word, other_word]
           end
-
-          it "doesn't populate the previous entries" do
-            entry.push(next_word)
-            expect(entry.previous_word).to be_nil
-          end
-
-          it "samples from the entered words", temporary_srand: 17 do
-            # fix the order of sampling so we can reproduce the test
-            entry.push(next_word)
-            entry.push(other_word)
-            if RUBY_PLATFORM == "java"
-              result = [next_word, other_word, other_word, other_word, other_word, next_word, next_word]
-            else
-              result = [next_word, next_word, other_word, next_word, other_word, next_word, other_word]
-            end
-            expect(7.times.map { entry.next_word }).to eq(result.map(&:to_s))
-          end
-        end
-
-        context "going backward" do
-          it "returns the next word if desired" do
-            # since there's only one word it'll always return the same value
-            entry.push(next_word, direction: :backwards)
-            expect(entry.previous_word).to eq(next_word.to_s)
-          end
-
-          it "doesn't populate the forward entries" do
-            entry.push(next_word, direction: :backwards)
-            expect(entry.next_word).to be_nil
-          end
-
-          it "samples from the entered words", temporary_srand: 17 do
-            # fix the order of sampling so we can reproduce the test
-            entry.push(next_word, direction: :backwards)
-            entry.push(other_word, direction: :backwards)
-            if RUBY_PLATFORM == "java"
-              result = [next_word, other_word, other_word, other_word, other_word, next_word, next_word]
-            else
-              result = [next_word, next_word, other_word, next_word, other_word, next_word, other_word]
-            end
-            expect(7.times.map { entry.previous_word }).to eq(result.map(&:to_s))
-          end
+          expect(7.times.map { entry.next_word }).to eq(result.map(&:to_s))
         end
       end
 
       describe "#==" do
         it "is equal if the word and both directions are the same" do
           entry.push(next_word)
-          entry.push(other_word, direction: :backwards)
+          entry.push(other_word)
           other_entry = DictionaryEntry.new(word)
           other_entry.push(next_word)
-          other_entry.push(other_word, direction: :backwards)
+          other_entry.push(other_word)
           expect(entry).to eq(other_entry)
         end
 
         it "is not equal if the base word is different" do
           entry.push(next_word)
-          entry.push(other_word, direction: :backwards)
+          entry.push(other_word)
           other_entry = DictionaryEntry.new(word + "Hello")
           other_entry.push(next_word)
-          other_entry.push(other_word, direction: :backwards)
+          other_entry.push(other_word)
           expect(entry).not_to eq(other_entry)
         end
 
-        it "is not equal if the forward direction is different" do
+        it "is not equal if the transitions are different" do
           entry.push(next_word)
-          entry.push(other_word, direction: :backwards)
+          entry.push(other_word)
           other_entry = DictionaryEntry.new(word)
           other_entry.push(Tokeneyes::Word.new(word + "Hello"))
-          other_entry.push(other_word, direction: :backwards)
-          expect(entry).not_to eq(other_entry)
-        end
-
-        it "is not equal if the backward direction is different" do
-          entry.push(next_word)
-          entry.push(other_word, direction: :backwards)
-          other_entry = DictionaryEntry.new(word)
-          other_entry.push(next_word)
-          other_entry.push(Tokeneyes::Word.new(other_word.to_s + "foo"), direction: :backwards)
+          other_entry.push(other_word)
           expect(entry).not_to eq(other_entry)
         end
 


### PR DESCRIPTION
An earlier implementation supported the ability to compile chains that went both forward and backward; while the forward direction behaves as you'd expect, the backward direction would allow you to start in the middle of a sentence and construct the earlier words. (This is useful if you know you wanted to build around a particular word but didn't want it to be the start of the sentence.)

Unfortunately, subsequent changes to the code have made it more and more painful to maintain the vestigial backward-facing code. Instead of holding onto it indefinitely, it's going to be easier to build out the full range of forward-facing functionality. Later, once that design is finished, I'll figure out how to adjust it to support backward-facing transitions.
